### PR TITLE
Old symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Visit [https://github-music.vercel.app](https://github-music.vercel.app), go thr
 ### Supported files
 
 1. Audios:
+
    - wav
    - mp3
    - mp4
@@ -18,7 +19,7 @@ Visit [https://github-music.vercel.app](https://github-music.vercel.app), go thr
    - ogg
    - webm
    - flac
-   - Symbolic links to supported audio files
+   - [Symbolic links to supported audio files](#symlinks)
 
 2. Images:
    - jpg
@@ -30,6 +31,17 @@ Visit [https://github-music.vercel.app](https://github-music.vercel.app), go thr
 ### How to include images
 
 The app will look for images within the folder contents. Songs will pick the images at same level, while symlinks will search in their origins.
+
+### Symlinks
+
+Symlinks have an interesting behavior. All _valid_ symlinks will work as expected. However, due to GitHub's API interpretation of "valid symlink to file", performance will be heavily affected. Hence the support for _invalid_ symlinks.
+
+- Valid symlinks are those that point to a file that exists in the repository and have a relative path to it.
+- Invalid symlinks are those that point to a file that **does** exist in the repository, but have an absolute path to it (aka, starts with "/"), where root is the root of the repository.
+
+Although invalid symlinks won't work in a local environment, they will work in GitHub Music.
+
+It's up to you to decide if you want compatibility or performance.
 
 ### Small UX things that will change
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Visit [https://github-music.vercel.app](https://github-music.vercel.app), go thr
 ### Supported files
 
 1. Audios:
-
    - wav
    - mp3
    - mp4

--- a/src/lib/server/github.ts
+++ b/src/lib/server/github.ts
@@ -58,17 +58,22 @@ export async function getSymlinkTarget(
 	try {
 		const request = await getRepoFile(auth, owner, repo, path, ref);
 
-		/**
-		 * Ironic, data.type === "symlink" isn't our supported symlink type
-		 * @see https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#if-the-content-is-a-symlink
-		 */
-		if (Array.isArray(request.data) || request.data.type !== 'file' || !request.data.download_url) {
+		if (Array.isArray(request.data)) {
 			return null;
 		}
 
+		// Just hope the user isn't wrong and the symlink targets a file
+		if (request.data.type === 'symlink') {
+			return request.data.target || null;
+		}
+
 		// Just hope the user isn't wrong and the file is a symlink
-		const response = await fetch(request.data.download_url);
-		return await response.text();
+		if (request.data.type === 'file' && request.data.download_url) {
+			const response = await fetch(request.data.download_url);
+			return (await response.text()) || null;
+		}
+
+		return null;
 	} catch (error) {
 		return null;
 	}

--- a/src/routes/listen/[name]/[repo]/[branch]/[...path]/+page.server.ts
+++ b/src/routes/listen/[name]/[repo]/[branch]/[...path]/+page.server.ts
@@ -11,10 +11,9 @@ class Folder {
 	readonly '..': Folder;
 	[path: string]: Folder | number;
 
-	constructor(root?: Folder, parent?: Folder) {
+	constructor(parent?: Folder) {
 		this['.'] = this;
 		this['..'] = parent ?? this;
-		this[''] = root ?? this;
 	}
 }
 
@@ -57,7 +56,7 @@ export const load = (async ({ params, cookies, setHeaders, fetch }) => {
 				current[part] = parseInt(node.mode || '1');
 			} else {
 				if (!current[part]) {
-					current[part] = new Folder(root, current);
+					current[part] = new Folder(current);
 				}
 
 				current = current[part] as Folder;
@@ -107,7 +106,7 @@ export const load = (async ({ params, cookies, setHeaders, fetch }) => {
 		const file = cwd[filename];
 
 		if (file instanceof Folder) {
-			if (['', '.', '..'].includes(filename)) continue;
+			if (filename === '.' || filename === '..') continue;
 
 			const cover_path = findCover(file, join(list.path, filename));
 
@@ -240,7 +239,7 @@ function getDir(
 	let dir = start as Folder | null;
 	let parent = null as Folder | null;
 	for (const filename of path.split('/')) {
-		if (!dir) break;
+		if (!filename || !dir) break;
 
 		if (!Object.prototype.hasOwnProperty.call(dir, filename)) {
 			return { found: false, dir, parent };

--- a/src/routes/listen/[name]/[repo]/[branch]/[...path]/+page.server.ts
+++ b/src/routes/listen/[name]/[repo]/[branch]/[...path]/+page.server.ts
@@ -11,9 +11,10 @@ class Folder {
 	readonly '..': Folder;
 	[path: string]: Folder | number;
 
-	constructor(parent?: Folder) {
+	constructor(root?: Folder, parent?: Folder) {
 		this['.'] = this;
 		this['..'] = parent ?? this;
+		this[''] = root ?? this;
 	}
 }
 
@@ -56,7 +57,7 @@ export const load = (async ({ params, cookies, setHeaders, fetch }) => {
 				current[part] = parseInt(node.mode || '1');
 			} else {
 				if (!current[part]) {
-					current[part] = new Folder(current);
+					current[part] = new Folder(root, current);
 				}
 
 				current = current[part] as Folder;
@@ -106,7 +107,7 @@ export const load = (async ({ params, cookies, setHeaders, fetch }) => {
 		const file = cwd[filename];
 
 		if (file instanceof Folder) {
-			if (filename === '.' || filename === '..') continue;
+			if (['', '.', '..'].includes(filename)) continue;
 
 			const cover_path = findCover(file, join(list.path, filename));
 
@@ -239,7 +240,7 @@ function getDir(
 	let dir = start as Folder | null;
 	let parent = null as Folder | null;
 	for (const filename of path.split('/')) {
-		if (!filename || !dir) break;
+		if (!dir) break;
 
 		if (!Object.prototype.hasOwnProperty.call(dir, filename)) {
 			return { found: false, dir, parent };


### PR DESCRIPTION
You might ask why. Simple answer: performance.

Long answer: GitHub API for _valid_ symlinks is terrible, forcing you to make an extra request to get the target. Invalid symlinks, on the other hand, require no extra request, hence they are more performance friendly.

Surprisingly, it was super easy to reimplement :smile: